### PR TITLE
Gnuradio gui swap

### DIFF
--- a/gnuradio/downlink/downlink-double.grc
+++ b/gnuradio/downlink/downlink-double.grc
@@ -191,7 +191,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>speed_tab@0</value>
+      <value>speed_tab@1</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -238,7 +238,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>speed_tab@1</value>
+      <value>speed_tab@0</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -367,11 +367,11 @@
     </param>
     <param>
       <key>label0</key>
-      <value>&amp;1 - 1200 bps</value>
+      <value>&amp;1 - 9600 bps</value>
     </param>
     <param>
       <key>label1</key>
-      <value>&amp;2 - 9600 bps</value>
+      <value>&amp;2 - 1200 bps</value>
     </param>
     <param>
       <key>label10</key>

--- a/gnuradio/downlink/downlink-hier.grc
+++ b/gnuradio/downlink/downlink-hier.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.13'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Mon Aug 21 11:43:56 2017</timestamp>
   <block>
@@ -257,7 +257,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>5,0,1,2</value>
+      <value>16,0,1,2</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -504,7 +504,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>1,0,1,1</value>
+      <value>12,0,1,1</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -719,7 +719,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>3,0,1,1</value>
+      <value>14,0,1,1</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -801,7 +801,7 @@
     </param>
     <param>
       <key>gui_hint</key>
-      <value>1,1,1,1</value>
+      <value>12,1,1,1</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2157,7 +2157,7 @@ class frames_counter(gr.sync_block):
     </param>
     <param>
       <key>gui_hint</key>
-      <value>4,0,1,2</value>
+      <value>15,0,1,2</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2452,7 +2452,7 @@ class frames_counter(gr.sync_block):
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1144, 560)</value>
+      <value>(1144, 564)</value>
     </param>
     <param>
       <key>gui_hint</key>
@@ -4067,7 +4067,7 @@ class frames_counter(gr.sync_block):
     </param>
     <param>
       <key>gui_hint</key>
-      <value>2,0,1,2</value>
+      <value>13,0,1,2</value>
     </param>
     <param>
       <key>_rotation</key>


### PR DESCRIPTION
Stopped scrolling during every session.

- Swapped 1200 and 9600 tabs
- Swapped controls inside downlink tab to remove scrolling during every session