### PR TITLE
Temperature warning and error frames in GS slack uploader

### DIFF
--- a/tools/gs_to_slack_uploader/slack_upload.py
+++ b/tools/gs_to_slack_uploader/slack_upload.py
@@ -73,6 +73,8 @@ class UploadSlack(Thread):
                 # filter out FileSendSuccessFrame
                 if isinstance(decoded_frame, response_frames.common.FileSendSuccessFrame):
                     self.logger.log(logging.DEBUG, frame_text)
+                elif isinstance(decoded_frame, response_frames.common.FileSendErrorFrame):
+                    self.logger.log(logging.DEBUG, frame_text)
                 else:
                     requests.post(self.slack_url, json={'username': 'GS Frames', 'text': formated_message})
 


### PR DESCRIPTION
- lowered temperature warning in beacon to -4 Celsius
- removed FileDownloadError frames from GS slack uploads.